### PR TITLE
Evil Fish Death Tracker V2

### DIFF
--- a/Scripts/EvilFishDeathTracker/README.txt
+++ b/Scripts/EvilFishDeathTracker/README.txt
@@ -12,6 +12,7 @@ News article shown each year with the number of evil fish killed
 On initial game launch, add all river tiles to a list.
 Each year check if each tile in the list is still a river tile.
 For each one which is no longer a river tile, remove it from the list and increase the number of evil fish killed (1-10 per tile).
+If the single-width setting is enabled (on by default), surrounding tiles are checked so that only single-width rivers are considered for evil fish.
 ---
 
 ## 📦 What's It For?

--- a/Scripts/EvilFishDeathTracker/info.nut
+++ b/Scripts/EvilFishDeathTracker/info.nut
@@ -2,7 +2,8 @@ class FMainClass extends GSInfo {
 	function GetAuthor()		{ return "Cookie"; }
 	function GetName()			{ return "Evil Fish Death Tracker"; }
 	function GetDescription() 	{ return "A fun script which displays a news article each year with the number of evil fish which have been killed by bombing river tiles"; }
-	function GetVersion()		{ return 1; }
+	function GetVersion()		{ return 2; }
+	function MinVersionToLoad() { return 1; }
 	function GetDate()			{ return "2025/08/16"; }
 	function CreateInstance()	{ return "MainClass"; }
 	function GetShortName()		{ return "EFDT"; }
@@ -10,6 +11,12 @@ class FMainClass extends GSInfo {
 	function GetUrl()			{ return ""; }
 
 	function GetSettings() {
+		AddSetting({
+			name = "single_width_setting",
+			description = "Evil fish only exist in single-width river tiles",
+			default_value = 1,
+			flags = CONFIG_NONE | CONFIG_BOOLEAN
+		});
 	}
 }
 


### PR DESCRIPTION
Adds a setting to only consider single-width rivers as containing evil fish (enabled by default).

If wider rivers are reduced to single-width, these will become new breeding grounds for evil fish. Once all the evil fish have been eradicated, reducing rivers to single-width has no effect.