### PR TITLE
Make sure UFO crash isn't counted as road crash

### DIFF
--- a/Scripts/StatTracker/main.nut
+++ b/Scripts/StatTracker/main.nut
@@ -149,7 +149,7 @@ function MainClass::HandleEvents()
 				local reason = crash.GetCrashReason();
 				switch(reason) {
 					case GSEventVehicleCrashed.CRASH_TRAIN: this.stat_train_crashes += 1; break;
-					case GSEventVehicleCrashed.CRASH_RV_UFO:
+					case GSEventVehicleCrashed.CRASH_RV_UFO: break;
 					case GSEventVehicleCrashed.CRASH_RV_LEVEL_CROSSING: this.stat_road_crashes += 1; break;
 					case GSEventVehicleCrashed.CRASH_AIRCRAFT_NO_AIRPORT: this.stat_plane_crashes += stat_plane_crashes; break;
 					case GSEventVehicleCrashed.CRASH_PLANE_LANDING: this.stat_plane_crashes += stat_plane_crashes; break;


### PR DESCRIPTION
The Squirrel lang docs aren't entirely clear, but it seems like without the `break`, that the UFO would fall down to the road case, and thus be counted as one.